### PR TITLE
Use paplay for Linux sound playback

### DIFF
--- a/ICM.bash
+++ b/ICM.bash
@@ -495,8 +495,12 @@ playSound() {
     afplay "$MY_SOUND"
     say -v Whisper "$phrase"
   elif [ "$OS" == "LINUX" ]; then
-    echo "FALTA SOUND"
-    exit 1
+    if command -v paplay >/dev/null 2>&1; then
+      paplay "$MY_SOUND"
+    else
+      echo "FALTA SOUND"
+      exit 1
+    fi
   fi
 }
 evidence() {


### PR DESCRIPTION
When the user connects to the internet, ICM tries to reproduce a sound. In the case of linux, this feature wasn't implemented, and it simply exited the program. Now it actually plays a sound and continues running unless paplay doesn't work.

before:
![image](https://github.com/user-attachments/assets/ca438cc9-c466-488c-a303-9a88605201bf)
after: 
![image](https://github.com/user-attachments/assets/dcdcc0eb-71bf-4813-9a01-0a4cc46752d6)
